### PR TITLE
use  "actions/checkout" before this setup gcp

### DIFF
--- a/.github/workflows/gcpdeploy.yml
+++ b/.github/workflows/gcpdeploy.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: GCP
     steps:
+      - uses: actions/checkout@v2
       - id: 'auth'
         uses: 'google-github-actions/auth@v0'
         with:
@@ -19,7 +20,6 @@ jobs:
         uses: 'google-github-actions/setup-gcloud@v0'
       - name: 'Use gcloud CLI'
         run: 'gcloud info'
-      - uses: actions/checkout@v2
       - name: Deploy to GCF
         run: |
           gcloud functions deploy protector-app-bot \


### PR DESCRIPTION
Warning: The "create_credentials_file" option is true, but the current GitHub workspace is empty. Did you forget to use "actions/checkout" before this step? If you do not intend to share authentication with future steps in this job, set "create_credentials_file" to false.
Created credentials file at "/home/runner/work/protector-app-bot/protector-app-bot/gha-creds-e58feabb431df3ca.json"